### PR TITLE
Cкрипты для Ярна и нпма

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,45 @@
 #Инитум
 Шаблон помогает быстро начать вёрстку проекта.
 
-Перед первым запуском:
+Перед началом работы нужно установить зависимости:
 ```bash
-sudo npm install
+npm install
+```
+Можно Ярном, если есть:
+```bash
+yarn
 ```
 
 ##Режимы
 Одноразовая сборка:
 ```bash
-gulp
+npm start
+```
+```bash
+yarn start
 ```
 
 Запуск живой сборки на локальном сервере:
 ```bash
-gulp live
+npm run live
+```
+```bash
+yarn live
 ```
 
 Живая сборка на локальном сервере и туннель в интернет:
 ```bash
-gulp external-world
+npm run external-world
+```
+```bash
+yarn external-world
 ```
 
 ##Шаблонизация
-Шаблоны собираются в папке `templates` с помощью тегов `<include>`. Составные части лежат в `blocks`. Переменные — через `@@var` (см. [gulp-html-tag-include](https://github.com/straykov/gulp-html-tag-include)). Боевые файлы автоматически собираются в корне проекта.
+Шаблоны собираются из папки `templates` с помощью [pug](https://pugjs.org). Составные части лежат в `blocks`. Боевые файлы автоматически собираются в корне проекта.
 
 ##Стили
-Верстаются в `assets/source/styles/layout.css`, компилируются в `assets/css/style.css`.
+Верстаются в `assets/source/styles/layout.pcss`, компилируются в `assets/css/style.css`. Работает антикэш.
 
 ####PostCSS
 Переменные ([postcss-simple-vars](https://github.com/postcss/postcss-simple-vars)):
@@ -48,6 +61,15 @@ $f_Helvetica: "Helvetica Neue", Arial, sans-serif;
 }
 ```
 [CSSNext](http://cssnext.io). Штуки из CSS 4, префиксы, кастомные медиа-запросы.
+
+##Сжатие картинок
+Картинки кладутся в `assets/source/img/` и с помощью [gulp-imagemin](https://www.npmjs.com/package/gulp-imagemin) минифицируются в папку `assets/img/`.
+
+##Скрипты
+Можно писать на es2015 — подключен и работает Бабель. Включен jQuery 3. Работает антикэш.
+
+##Авторы
+[Илья Страйков](https://github.com/straykov), [Кирилл Чернаков](https://github.com/Kiryous), [Олег Алешкин](https://github.com/AleshaOleg), [Арсений Максимов](https://github.com/notarseniy).
 
 --
 Используется в проектах [Кодельной](http://code.straykov.ru) <img src="http://code.straykov.ru/assets/img/logo.svg" height="19"> и [Гридли](http://gridly.ru)

--- a/package.json
+++ b/package.json
@@ -1,27 +1,58 @@
 {
   "name": "Initium",
-  "version": "2.1.3",
+  "version": "3.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/straykov/initium.git"
   },
+  "scripts": {
+    "start": "node ./node_modules/gulp/bin/gulp.js",
+    "live": "node ./node_modules/gulp/bin/gulp.js live",
+    "external-world": "NODE_ENV=production node ./node_modules/gulp/bin/gulp.js external-world"
+  },
   "devDependencies": {
     "autoprefixer": "^6.3.6",
+    "babel-preset-es2015": "^6.18.0",
     "browser-sync": "^2.12.3",
+    "del": "^2.2.2",
     "gulp": "^3.9.1",
+    "gulp-babel": "^6.1.2",
+    "gulp-cache-bust": "^1.0.2",
+    "gulp-cached": "^1.1.0",
     "gulp-concat": "^2.6.0",
     "gulp-cssnano": "^2.1.2",
-    "gulp-eslint": "^2.0.0",
-    "gulp-html-tag-include": "^1.0.1",
+    "gulp-eslint": "^3.0.1",
+    "gulp-imagemin": "^3.1.1",
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.1.0",
+    "gulp-pug": "^3.1.0",
+    "gulp-remember": "^0.3.1",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.3",
     "gulp-util": "^3.0.7",
+    "path": "^0.12.7",
     "portfinder": "^1.0.3",
     "postcss-cssnext": "^2.5.2",
     "postcss-import": "^8.1.0",
+    "postcss-inline-svg": "^2.1.2",
     "postcss-nested": "^1.0.0",
     "postcss-simple-vars": "^1.2.0"
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
+  },
+  "eslintConfig": {
+    "parserOptions": {
+      "ecmaVersion": 6
+    },
+    "env": {
+      "browser": true,
+      "es6": true
+    },
+    "rules": {
+      "semi": 2
+    }
   }
 }


### PR DESCRIPTION
Сделал всё как у людей.

Теперь Инитум запускается через Ярн или нпм. Глобальный галп ставить для этого не нужно.

Обновил док с новыми командами (и убрал sudo перед npm install — грешновато!).